### PR TITLE
Terminate output with newline (fixes #5)

### DIFF
--- a/main.go
+++ b/main.go
@@ -271,4 +271,5 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	fmt.Println()
 }


### PR DESCRIPTION
I didn't need to edit the test script here (unless I'm running it incorrectly -- `bash scripts/test.sh` in zsh).

https://github.com/multiprocessio/dsq/blob/dedd036b10c5e2b2991bc27ef94204eed8c0703f/scripts/test.sh#L27-L38

Maybe the subshell strips out additional newlines? It seems to do that when I try this in my shell:

```
> a="$(printf "\n\n\n\n\n\n")" echo $a

> echo ""
 
>
```