### PR TITLE
Upgrade to Go 1.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ and add `dsq` to your `$PATH`.
 ### Build and install from source
 
 If you are on another platform or architecture or want to grab the
-latest release, you can do so with Go 1.17+:
+latest release, you can do so with Go 1.18+:
 
 ```bash
 $ go install github.com/multiprocessio/dsq@latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/multiprocessio/dsq
 
-go 1.17
+go 1.18
 
 // Uncomment for local development
 // replace github.com/multiprocessio/datastation/runner => ../datastation/runner

--- a/go.sum
+++ b/go.sum
@@ -79,7 +79,6 @@ github.com/Azure/go-autorest/tracing v0.6.0 h1:TYi4+3m5t6K48TGI9AUdb+IzbnSxvnvUM
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/ClickHouse/clickhouse-go v1.5.3 h1:Vok8zUb/wlqc9u8oEqQzBMBRDoFd8NxPRqgYEqMnV88=
 github.com/ClickHouse/clickhouse-go v1.5.3/go.mod h1:EaI/sW7Azgz9UATzd5ZdZHRUhHgv5+JMS9NSr2smCJI=
 github.com/ClickHouse/clickhouse-go/v2 v2.0.12 h1:Nbl/NZwoM6LGJm7smNBgvtdr/rxjlIssSW3eG/Nmb9E=
 github.com/ClickHouse/clickhouse-go/v2 v2.0.12/go.mod h1:u4RoNQLLM2W6hNSPYrIESLJqaWSInZVmfM+MlaAhXcg=
@@ -173,7 +172,6 @@ github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4Yn
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
-github.com/cespare/xxhash v1.1.0 h1:a6HrQnmkObjyL+Gs60czilIUGqrzKutQD6XZog3p+ko=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/cespare/xxhash/v2 v2.1.1/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
@@ -475,7 +473,6 @@ github.com/paulmach/protoscan v0.2.1-0.20210522164731-4e53c6875432/go.mod h1:2sV
 github.com/pborman/getopt v0.0.0-20180729010549-6fdd0a2c7117/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/phpdave11/gofpdf v1.4.2/go.mod h1:zpO6xFn9yxo3YLyMvW8HcKWVdbNqgIfOOp2dXMnm1mY=
 github.com/phpdave11/gofpdi v1.0.12/go.mod h1:vBmVV0Do6hSBHC8uKUQ71JGW+ZGQq74llk/7bXwjDoI=
-github.com/pierrec/lz4 v2.0.5+incompatible h1:2xWsjqPFWcplujydGg4WmhC/6fZqK42wMM8aXeqhl0I=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
 github.com/pierrec/lz4/v4 v4.1.8/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=
 github.com/pierrec/lz4/v4 v4.1.11/go.mod h1:gZWDp/Ze/IJXGXf23ltt2EXimqmTUXEy0GFuRQyBid4=

--- a/scripts/ci/prepare_linux.sh
+++ b/scripts/ci/prepare_linux.sh
@@ -2,8 +2,8 @@
 
 set -ex
 
-sudo curl -LO https://go.dev/dl/go1.17.4.linux-amd64.tar.gz
+sudo curl -LO https://go.dev/dl/go1.18.linux-amd64.tar.gz
 sudo rm -rf /usr/local/go
-sudo tar -C /usr/local -xzf go1.17.4.linux-amd64.tar.gz
+sudo tar -C /usr/local -xzf go1.18.linux-amd64.tar.gz
 sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
 sudo ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt

--- a/scripts/ci/prepare_macos.sh
+++ b/scripts/ci/prepare_macos.sh
@@ -5,5 +5,5 @@ set -eux
 sudo curl -LO https://go.dev/dl/go1.18.darwin-amd64.tar.gz
 sudo rm -rf /usr/local/go
 sudo tar -C /usr/local -xzf go1.18.darwin-amd64.tar.gz
-sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
-sudo ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt
+sudo mv /usr/local/go/bin/go /usr/local/bin/go
+sudo mv /usr/local/go/bin/gofmt /usr/local/bin/gofmt

--- a/scripts/ci/prepare_macos.sh
+++ b/scripts/ci/prepare_macos.sh
@@ -2,6 +2,8 @@
 
 set -eux
 
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-brew uninstall go@1.15
-brew install go@1.18 jq
+sudo curl -LO https://go.dev/dl/go1.18.darwin-amd64.tar.gz
+sudo rm -rf /usr/local/go
+sudo tar -C /usr/local -xzf go1.18.darwin-amd64.tar.gz
+sudo ln -s /usr/local/go/bin/go /usr/local/bin/go
+sudo ln -s /usr/local/go/bin/gofmt /usr/local/bin/gofmt

--- a/scripts/ci/prepare_macos.sh
+++ b/scripts/ci/prepare_macos.sh
@@ -4,4 +4,4 @@ set -eux
 
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew uninstall go@1.15
-brew install go jq
+brew install go@1.18 jq

--- a/scripts/ci/prepare_windows.ps1
+++ b/scripts/ci/prepare_windows.ps1
@@ -5,7 +5,9 @@ scoop install jq zip curl
 
 curl -L -O "https://go.dev/dl/go1.18.windows-amd64.zip"
 unzip go1.18.windows-amd64.zip
-ls
-ls go1.18.windows-amd64
-cp go1.18.windows-amd64\go (Join-Path (Resolve-Path ~).Path "scoop\shims")\go
-cp go1.18.windows-amd64\gofmt (Join-Path (Resolve-Path ~).Path "scoop\shims")\gofmt
+ls go
+ls go\bin
+Join-Path $pwd "go\bin" >> $Env:GITHUB_PATH
+which go
+where go
+go version

--- a/scripts/ci/prepare_windows.ps1
+++ b/scripts/ci/prepare_windows.ps1
@@ -1,4 +1,11 @@
 iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/install.ps1' -outfile 'install.ps1'
 .\install.ps1 -RunAsAdmin
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
-scoop install go@1.18 jq zip
+scoop install jq zip curl
+
+curl -L -O "https://go.dev/dl/go1.18.windows-amd64.zip"
+unzip go1.18.windows-amd64.zip
+ls
+ls go1.18.windows-amd64
+cp go1.18.windows-amd64\go (Join-Path (Resolve-Path ~).Path "scoop\shims")\go
+cp go1.18.windows-amd64\gofmt (Join-Path (Resolve-Path ~).Path "scoop\shims")\gofmt

--- a/scripts/ci/prepare_windows.ps1
+++ b/scripts/ci/prepare_windows.ps1
@@ -1,4 +1,4 @@
 iwr -useb 'https://raw.githubusercontent.com/scoopinstaller/install/master/install.ps1' -outfile 'install.ps1'
 .\install.ps1 -RunAsAdmin
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
-scoop install go jq zip
+scoop install go@1.18 jq zip

--- a/scripts/ci/prepare_windows.ps1
+++ b/scripts/ci/prepare_windows.ps1
@@ -5,9 +5,4 @@ scoop install jq zip curl
 
 curl -L -O "https://go.dev/dl/go1.18.windows-amd64.zip"
 unzip go1.18.windows-amd64.zip
-ls go
-ls go\bin
 Join-Path $pwd "go\bin" >> $Env:GITHUB_PATH
-which go
-where go
-go version


### PR DESCRIPTION
Depends on https://github.com/ScoopInstaller/Main/pull/3392 and https://github.com/Homebrew/homebrew-core/pull/91369