### PR TITLE
Handle return after getArgs

### DIFF
--- a/main.go
+++ b/main.go
@@ -337,6 +337,11 @@ func _main() error {
 		return err
 	}
 
+	// Some commands exit naturally here. Like -h and -v
+	if args == nil {
+		return nil
+	}
+
 	lastNonFlagArg := ""
 	files := args.nonFlagArgs
 

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -171,6 +171,11 @@ to_run = """./dsq ./testdata/avro/test_data.avro 'SELECT COUNT(*) FROM {} WHERE 
 want = '[{"COUNT(*)":25}]'
 test("Supports Avro files", to_run, want, sort=True)
 
+# Version test
+to_run = """./dsq -v"""
+want_stderr = "dsq latest\n"
+test("Shows version and quits", to_run, want="", want_stderr=want_stderr)
+
 # Pretty column order
 to_run = """./dsq --pretty testdata/path/path.json 'SELECT name, id FROM {"data.data"}'"""
 want = """+----+-------+


### PR DESCRIPTION
Fixes:

```
$ dsq -v
dsq 0.15.0
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x5641bd9700e2]

goroutine 1 [running]:
main._main()
        github.com/multiprocessio/dsq/main.go:341 +0x62
main.main()
        github.com/multiprocessio/dsq/main.go:502 +0x19
```