### PR TITLE
Handle 0 rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -454,6 +454,11 @@ file into SQLite.
 So even if you change the query, as long as the file doesn't change,
 the cache is effective.
 
+### Interactive REPL
+
+Use the `-i` or `--interactive` flag to enter an interactive REPL
+where you can run multiple SQL queries.
+
 ## Supported Data Types
 
 | Name | File Extension(s) | Mime Type | Notes |

--- a/README.md
+++ b/README.md
@@ -459,6 +459,19 @@ the cache is effective.
 Use the `-i` or `--interactive` flag to enter an interactive REPL
 where you can run multiple SQL queries.
 
+```
+$ dsq some-large-file.json -i
+dsq> SELECT COUNT(1) FROM {};
++----------+
+| COUNT(1) |
++----------+
+|     1000 |
++----------+
+(1 row)
+dsq> SELECT * FROM {} WHERE NAME = 'Kevin';
+(0 rows)
+```
+
 ## Supported Data Types
 
 | Name | File Extension(s) | Mime Type | Notes |

--- a/scripts/test.py
+++ b/scripts/test.py
@@ -183,7 +183,8 @@ want = """+----+-------+
 +----+-------+
 |  1 | Corah |
 |  3 | Minh  |
-+----+-------+"""
++----+-------+
+(2 rows)"""
 test("Pretty column order alphabetical", to_run, want)
 
 # Pretty without query
@@ -192,7 +193,8 @@ want = """+---+---+-------+
 | a | b |   c   |
 +---+---+-------+
 | 1 | 2 | [1,2] |
-+---+---+-------+"""
++---+---+-------+
+(1 row)"""
 test("Pretty works even without query", to_run, want)
 
 # Prints schema pretty


### PR DESCRIPTION
Zero rows was breaking the REPL for some reason but not regular code. This may be a real bug in DataStation shape code but for now we just look for a 0 byte file.