### PR TITLE
Add note how to keep column order with piping

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,14 @@ $ dsq --pretty testdata/userdata.parquet 'select count(*) from {}'
 +----------+
 ```
 
+An alternative that also contains the original order of the columns in the select,
+is to pipe it into a program that can output pretty table.
+E.g. if you have [visidata](https://github.com/saulpw/visidata) installed, you could just call
+
+```bash
+$ dsq testdata/userdata.parquet 'select count(*) from {}' | vd -f json
+```
+
 ### Piping data to dsq
 
 When piping data to `dsq` you need to set the `-s` flag and specify


### PR DESCRIPTION
Losing column order via --pretty as specified in the SELECT is clear no go, but of course, we want to see tables as tables and not as json.

So, I added an example of how to pipe it into a specialiced tabular tool (here: visidata, what is a vim like spreadsheet tool) that shows the table beautiful and efficient in the specified order.

I'm not sure whether this high level tool (with similar functionality as excel) is really the best example, but wanted to make at least a suggestion as a starting point for discussion.

As said, losing the order in a pretty view is all, but certainly not pretty.